### PR TITLE
separated modernizr.js and detectizr.js from the dependencies.js

### DIFF
--- a/implementation/index.html
+++ b/implementation/index.html
@@ -49,6 +49,8 @@
 
     <!--Dynamic JS polyfill (client browser specific)-->
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js" include="NONE" persist="true"></script>
+    <!--Modernizr and Detectizr-->
+    <script src="js/lib/modernizr-detectizr.js" exclude="starter-kit, framework-only" persist="true"></script>
     <div region="app"></div>
 
     <!--

--- a/implementation/starter-kit.index.html
+++ b/implementation/starter-kit.index.html
@@ -44,6 +44,8 @@
 
     <!--Dynamic JS polyfill (client browser specific)-->
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js" include="NONE" persist="true"></script>
+    <!--Modernizr and Detectizr-->
+    <script src="bower_components/stage/dist/js/lib/modernizr-detectizr.min.js"></script>
     <div region="app"></div>
 
     <!--


### PR DESCRIPTION
separated modernizr.js and detectizr.js from the dependencies.js;
newly built js is named modernizr-detectizr.js and modernizr-detectizr.min.js;
added script loading for index.html and starter-kit.index.html;

**
NOTE: 
Please run /tools/libprep/run.js before testing the changes on framework.
Also run /tools/build.sh before testing starter-kit changes.
Since I don't want to mess up the files for pull request, I didn't run it on this repo.
**
