### PR TITLE
changed dependent js libraries loading mechanism.

### DIFF
--- a/implementation/index.html
+++ b/implementation/index.html
@@ -53,9 +53,31 @@
 
     <!--========Infrastructure Space: the framework======================================================-->
     <!--Deps-->
-    <script src="js/lib/dependencies.js" exclude="starter-kit, framework-only" persist="true"></script>
+    <script src="bower_components/jquery/dist/jquery.js" include="NONE" persist="true"></script>
+    <script src="bower_components/underscore/underscore.js" include="NONE" persist="true"></script>
+    <script src="bower_components/loadcss/loadCSS.js" target="js/stage.js"></script>
+    <script src="bower_components/fastclick/lib/fastclick.js"></script>
+    <script src="bower_components/jquery-ui/ui/jquery-ui.js"></script>
+    <script src="bower_components/jquery-color/jquery.color.js"></script>
+    <script src="bower_components/js-cookie/src/js.cookie.js"></script>
+    <script src="bower_components/amaranjs/dist/js/jquery.amaran.js"></script>
+    <script src="bower_components/jquery-file-upload/js/jquery.fileupload.js"></script>
+    <script src="bower_components/flexlayout/flexlayout.js"></script>
+    <script src="bower_components/underscore.string/dist/underscore.string.js"></script>
+    <script src="bower_components/selectn/selectn.js"></script>
+    <script src="bower_components/validator-js/validator.js"></script>
+    <script src="bower_components/backbone/backbone.js"></script>
+    <script src="bower_components/marionette/lib/backbone.marionette.js"></script>
+    <script src="bower_components/handlebars/handlebars.js"></script>
+    <script src="bower_components/swag/lib/swag.js"></script>
+    <script src="bower_components/uri.js/src/URI.js"></script>
+    <script src="bower_components/store.js/store.js"></script>
+    <script src="bower_components/momentjs/moment.js"></script>
+    <script src="bower_components/marked/lib/marked.js"></script>
+    <script src="bower_components/later/later.js"></script>
+    <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
     <!--Deps Enhancement-/+-->
-    <script src="js/src/infrastructure/lib+-/bootstrap/tooltip.js" target="js/stage.js"></script>
+    <script src="js/src/infrastructure/lib+-/bootstrap/tooltip.js"></script>
     <script src="bower_components/bootstrap/js/popover.js"></script>
     <script src="js/src/infrastructure/lib+-/marked/marked.js"></script>
     <!--Infrastructure-->

--- a/implementation/starter-kit.bower.json
+++ b/implementation/starter-kit.bower.json
@@ -7,7 +7,9 @@
 		"jquery-ui": "1.10.4",
 		"amaranjs": "~0.5.x",
 		"animate.css": "~3.x.x",
-		"open-sans-fontface": "*"
+		"open-sans-fontface": "*",
+		"jquery": "~2.1.x",
+		"underscore": "~1.8.x"
 	},
 	"dependencies": {},
 	"open-source-libs": {

--- a/implementation/starter-kit.index.html
+++ b/implementation/starter-kit.index.html
@@ -53,7 +53,8 @@
 
     <!--========Infrastructure Space: the engine======================================================-->
     <!--Deps-->
-    <script src="bower_components/stage/dist/js/lib/dependencies.js"></script>
+    <script src="bower_components/jquery/dist/jquery.js"></script>
+    <script src="bower_components/underscore/underscore.js"></script>
     <script src="bower_components/stage/dist/js/stage.js"></script>
     <!--==============End of the engine===============================================================-->
 

--- a/tools/build/config.framework-only.js
+++ b/tools/build/config.framework-only.js
@@ -8,7 +8,6 @@ module.exports = {
 	},
 	structure : { //path are relative to the distFolder and src.root above
 		js: {
-			lib: 'js/lib',
 			'stage.js': false,
 			'stage.min.js': false,
 			'stage-widgets.js': false,


### PR DESCRIPTION
-- removed dependencies.js loading in index.html and starter-kit.index.html;

-- all dependent js libraries are being loaded individually in index.html and combined into js/lib/stage.js except jquery and underscore;

-- added loading jquery and underscore in starter-kit.index.html;

-- modified start-kit.bower.json to accommodate preceding changes;